### PR TITLE
Fix Enhanced Movement not working on reload

### DIFF
--- a/addons/overthrow_main/functions/save/fn_savePlayerData.sqf
+++ b/addons/overthrow_main/functions/save/fn_savePlayerData.sqf
@@ -7,7 +7,7 @@ private _data = [];
 	_data pushback [_x,_player getVariable _x];
 }foreach(allVariables _player select {
 	_x = toLower _x;
-	!(_x in ["ot_loaded", "morale", "player_uid", "sa_tow_actions_loaded", "hiding", "randomValue", "saved3deninventory"])
+	!(_x in ["ot_loaded", "morale", "player_uid", "sa_tow_actions_loaded", "hiding", "randomValue", "saved3deninventory", "babe_em_vars"])
 	&& { !((_x select [0,4]) in ["ace_", "cba_", "bis_"]) }
 	&& { (_x select [0,11]) != "missiondata" }
 	&& { (_x select [0,9]) != "seencache"}


### PR DESCRIPTION
Overthrow saved the state vars of Enhanced Movement preventing players from using it when logging in in some circumstances